### PR TITLE
Passed props into another page when a dining hall or dorm is clicked

### DIFF
--- a/frontend/src/components/ApartmentReviewOverview.js
+++ b/frontend/src/components/ApartmentReviewOverview.js
@@ -2,16 +2,22 @@ import { useState, useEffect } from "react";
 import { collection } from "firebase/firestore";
 import db from "../firebase";
 import Navbar from "./navbar";
-import { getPreviewCards, fetchData } from "./helpers";
+import { getPreviewCards, fetchOverview } from "./helpers";
+import { useNavigate } from "react-router-dom";
 
 const dormsRef = collection(db, "Dorms");
 
 export default function ApartmentReviewOverview() {
     const [previewCards, setPreviewCards] = useState([]);
-
+    const navigate = useNavigate();
+    
     useEffect(() => {
-        fetchData(dormsRef, setPreviewCards);
+        fetchOverview(dormsRef, setPreviewCards);
     }, []);
+
+    const handleDormSelect = (dorm) => {
+        navigate('/dormreviews', { state: { dorm }});
+    };
 
     return (
         <>
@@ -24,10 +30,11 @@ export default function ApartmentReviewOverview() {
                         <p>filters here</p>
                     </div>
                     <div className="previews">
-                        {getPreviewCards(previewCards)}
+                        {getPreviewCards(previewCards, handleDormSelect)}
                     </div>
                 </div>
             </div>
         </>
     );
 }
+

--- a/frontend/src/components/DiningReviewOverview.js
+++ b/frontend/src/components/DiningReviewOverview.js
@@ -2,16 +2,22 @@ import { useState, useEffect } from "react";
 import { collection } from "firebase/firestore";
 import db from "../firebase";
 import Navbar from "./navbar";
-import { getPreviewCards, fetchData } from "./helpers";
+import { getPreviewCards, fetchOverview } from "./helpers";
+import { useNavigate } from "react-router-dom";
 
 const diningHallsRef = collection(db, "DiningHalls");
 
 export default function DiningHallReviewOverview() {
     const [previewCards, setPreviewCards] = useState([]);
+    const navigate = useNavigate();
     
     useEffect(() => {
-        fetchData(diningHallsRef, setPreviewCards);
+        fetchOverview(diningHallsRef, setPreviewCards);
     }, []);
+
+    const handleDiningHallSelect = (diningHall) => {
+        navigate('/dininghallreviews', { state: { diningHall }});
+    };
 
     return (
         <>
@@ -24,7 +30,7 @@ export default function DiningHallReviewOverview() {
                         <p>filters here</p>
                     </div>
                     <div className="previews">
-                        {getPreviewCards(previewCards)}
+                        {getPreviewCards(previewCards, handleDiningHallSelect)}
                     </div>
                 </div>
             </div>

--- a/frontend/src/components/ViewDiningHallReviewInfo.js
+++ b/frontend/src/components/ViewDiningHallReviewInfo.js
@@ -1,0 +1,67 @@
+import { useState, useEffect } from "react";
+import { collection, doc, getDoc } from "firebase/firestore";
+import db from "../firebase";
+import Navbar from "./navbar";
+import { fetchDiningHallReviews, getPreviewCardsInfo } from "./helpers";
+import { useLocation } from 'react-router-dom';
+
+export default function ViewDiningHallReviewInfo({ diningHall }) {
+    const [previewCardsInfo, setPreviewCardsInfo] = useState([]);
+    const location = useLocation();
+    const [diningHallData, setDiningHallData] = useState([]);
+    const diningHallLoc = location.state.diningHall;
+    
+    function formatDiningHall(diningHallLoc) {
+        if (diningHallLoc == "Brittain Dining Hall") {
+            return "Brittain"
+        } else if (diningHallLoc == "North Avenue Dining Hall") {
+            return "Nav"
+        } else if (diningHallLoc == "West Village") {
+            return "Willage"
+        } 
+    }
+
+    useEffect(() => {
+        const fetchDiningHallData = async () => {
+            try {
+                const currDiningHallRef = doc(db, "DiningHalls", formatDiningHall(diningHallLoc));
+                const docSnap = await getDoc(currDiningHallRef);
+                if (docSnap.exists()) {
+                    setDiningHallData(docSnap.data());
+                } else {
+                    console.log("No such document!");
+                }
+            } catch (error) {
+                console.error("Error fetching dorm data: ", error);
+            }
+        };
+        fetchDiningHallData();
+
+        const diningHallsRef = collection(db, "DiningHalls", formatDiningHall(diningHallLoc), "Reviews");
+        fetchDiningHallReviews(diningHallsRef, setPreviewCardsInfo)
+    }, [diningHall]);
+
+    return (
+        <>
+            <Navbar />
+            <div className="reviewoverview">
+                <h1>Reviews</h1>
+                <h1>{diningHallData.name}</h1>
+                <h1>{diningHallData.address}</h1>
+                <h1>{diningHallData.numberChairs}</h1>
+                <h1>{diningHallData.numberReviews}</h1>
+                <h1>{diningHallData.overallRating}</h1>
+                <h1>{diningHallData.squareFootage}</h1>
+                <div className="main">
+                    <div className="filters">
+                        <h3>Filters</h3>
+                        <p>filters here</p>
+                    </div>
+                    <div className="previews">
+                        {getPreviewCardsInfo(previewCardsInfo)}
+                    </div>
+                </div>
+            </div>
+        </>
+    );
+}

--- a/frontend/src/components/ViewDormReviewInfo.js
+++ b/frontend/src/components/ViewDormReviewInfo.js
@@ -1,0 +1,59 @@
+import { useState, useEffect } from "react";
+import { collection, doc, getDoc } from "firebase/firestore";
+import db from "../firebase";
+import Navbar from "./navbar";
+import { fetchDormReviews, getPreviewCardsInfo } from "./helpers";
+import { useLocation } from 'react-router-dom';
+
+export default function ViewDormReviewInfo({ dorm }) {
+    const [previewCardsInfo, setPreviewCardsInfo] = useState([]);
+    const location = useLocation();
+    const [dormData, setDormData] = useState([]);
+    const dormLoc = location.state.dorm;
+
+    useEffect(() => {
+        const fetchDormData = async () => {
+            try {
+                const currDormRef = doc(db, "Dorms", dormLoc);
+                const docSnap = await getDoc(currDormRef);
+                if (docSnap.exists()) {
+                    setDormData(docSnap.data());
+                } else {
+                    console.log("No such document!");
+                }
+            } catch (error) {
+                console.error("Error fetching dorm data: ", error);
+            }
+        };
+        fetchDormData();
+
+        const dormsRef = collection(db, "Dorms", dormLoc, "Reviews");
+        fetchDormReviews(dormsRef, setPreviewCardsInfo)
+    }, [dorm]);
+
+    return (
+        <>
+            <Navbar />
+            <div className="reviewoverview">
+                <h1>Reviews</h1>
+                <h1>{dormData.name}</h1>
+                <h1>{dormData.address}</h1>
+                <h1>{dormData.bathrooms}</h1>
+                <h1>{dormData.elevator}</h1>
+                <h1>{dormData.laundry}</h1>
+                <h1>{dormData.numReviews}</h1>
+                <h1>{dormData.overallRating}</h1>
+                <h1>{dormData.squareFootage}</h1>
+                <div className="main">
+                    <div className="filters">
+                        <h3>Filters</h3>
+                        <p>filters here</p>
+                    </div>
+                    <div className="previews">
+                        {getPreviewCardsInfo(previewCardsInfo)}
+                    </div>
+                </div>
+            </div>
+        </>
+    );
+}

--- a/frontend/src/components/helpers.js
+++ b/frontend/src/components/helpers.js
@@ -1,18 +1,30 @@
 import PreviewCard from "./PreviewCard";
 import { getDocs } from "firebase/firestore";
 
-export function getPreviewCards(previewCards) {
+export function getPreviewCards(previewCards, handleSelect) {
     return previewCards.map((card, index) => (
+        <div key={index} onClick={() => handleSelect(card.name)}>
+            <PreviewCard
+                name={card.name}
+                subheading={card.address}
+                rating={card.overallRating}
+            />
+        </div>
+    ))
+}
+
+export function getPreviewCardsInfo(previewCardsInfo) {
+    return previewCardsInfo.map((card, index) => (
         <PreviewCard
             key={index}
-            name={card.name}
-            subheading={card.address}
-            rating={card.overallRating}
+            name={card.reviewMessage}
+            subheading={card.timestamp.toDate().toLocaleString()}
+            rating={card.rating}
         />
     ))
 }
 
-export const fetchData = async (docRef, setPreviewCards) => {
+export const fetchOverview = async (docRef, setPreviewCards) => {
     const querySnapshot = await getDocs(docRef);
     const reviews = querySnapshot.docs.map((doc) => ({
         name: doc.data().name,
@@ -21,4 +33,28 @@ export const fetchData = async (docRef, setPreviewCards) => {
     }));
     
     setPreviewCards(reviews);
+};
+
+export const fetchDiningHallReviews = async (docRef, setPreviewCardsInfo) => {
+    const querySnapshot = await getDocs(docRef);
+    const reviews = querySnapshot.docs.map((doc) => ({
+        rating: doc.data().rating,
+        reviewMessage: doc.data().reviewMessage,
+        timestamp: doc.data().timestamp,
+        voteScore: doc.data().voteScore
+    }));
+    
+    setPreviewCardsInfo(reviews);
+};
+
+export const fetchDormReviews = async (docRef, setPreviewCardsInfo) => {
+    const querySnapshot = await getDocs(docRef);
+    const reviews = querySnapshot.docs.map((doc) => ({
+        rating: doc.data().rating,
+        reviewMessage: doc.data().reviewMessage,
+        timestamp: doc.data().timestamp,
+        voteScore: doc.data().voteScore
+    }));
+    
+    setPreviewCardsInfo(reviews);
 };

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -12,6 +12,8 @@ import ProfessorsReviewOverview from './components/ProfessorsReviewOverview'
 import ClassesReviewOverview from './components/ClassesReviewOverview'
 import ApartmentReviewOverview from './components/ApartmentReviewOverview'
 import DiningReviewOverview from './components/DiningReviewOverview'
+import ViewDiningHallReviewInfo from './components/ViewDiningHallReviewInfo'
+import ViewDormReviewInfo from './components/ViewDormReviewInfo'
 
 const router = createBrowserRouter([
   {
@@ -41,6 +43,14 @@ const router = createBrowserRouter([
   {
     path: "/dininghalls",
     element: <DiningReviewOverview />
+  },
+  {
+    path: "/dininghallreviews",
+    element: <ViewDiningHallReviewInfo />
+  },
+  {
+    path: "/dormreviews",
+    element: <ViewDormReviewInfo />
   }
 ])
 


### PR DESCRIPTION
Passed props down when either dining hall or dorm is clicked. Displays all information about that specific dorm/dining hall, and all its reviews associated with it. However, I store the reviews in previewcards temporarily but I can't display voter score and the card dimensions are fixed, so we likely have to create a different card to store all its information. In addition, I display information about each dining hall/dorm when clicked in a h1 block, causing it to look strange. This could be formatted to look nicer, but the useState stores everything so that shouldn't be too difficult.

<img width="1044" alt="Screenshot 2023-11-07 at 7 17 10 PM" src="https://github.com/buzzwalk/reviews/assets/55965711/3a102c5c-1522-4963-aff5-011dfab5b133">
<img width="1054" alt="Screenshot 2023-11-07 at 7 17 16 PM" src="https://github.com/buzzwalk/reviews/assets/55965711/5b6baef8-3741-4bca-8ca8-5d6434f0c33f">

